### PR TITLE
Harden concurrent Pages deployments

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: pages-publish
+  group: pages-production
   cancel-in-progress: false
 
 jobs:
@@ -23,37 +23,16 @@ jobs:
       - name: Check out source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          path: source
           persist-credentials: false
 
       - name: Stage the site
-        working-directory: source
-        run: ./scripts/stage-site.sh "${RUNNER_TEMP}/site"
-
-      - name: Check out deployment branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: gh-pages
-          path: publish
+        run: ./scripts/stage-site.sh _site
 
       - name: Publish production
-        env:
-          SITE_DIRECTORY: ${{ runner.temp }}/site
-        run: |
-          rsync --archive --delete \
-            --exclude .git/ \
-            --exclude pr-preview/ \
-            "${SITE_DIRECTORY}/" publish/
-
-          cd publish
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add --all
-
-          if git diff --cached --quiet; then
-            echo "Production is already up to date."
-            exit 0
-          fi
-
-          git commit -m "Deploy production from ${GITHUB_SHA}"
-          git push origin HEAD:gh-pages
+        uses: JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23 # v4.7.4
+        with:
+          branch: gh-pages
+          folder: _site
+          clean-exclude: pr-preview
+          force: false
+          commit-message: Deploy production from ${{ github.sha }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pages-publish
+  group: pages-preview-${{ github.event.number }}
   cancel-in-progress: false
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The quality workflow runs the same checks for pull requests and pushes to `main`
 - GitHub Actions stages only the website files and publishes production to `gh-pages`.
 - Pull requests are published beneath `/pr-preview/pr-<number>/` and receive a preview link.
 - Preview files are removed automatically when their pull request closes.
-- The deployment workflows serialize writes so production and preview updates cannot race.
+- Production deploys preserve the preview directory and rebase instead of force-pushing deployment history.
+- Each pull request serializes its own preview updates so deploy and cleanup events stay ordered.
 
 The `gh-pages` branch is deployment output and should not be edited manually.


### PR DESCRIPTION
## Summary

- give production and each pull request independent concurrency groups
- publish production with the same rebase-safe deployment action used by previews
- preserve the pr-preview directory during production updates
- disable force pushes for production publishing

## Root cause

GitHub concurrency groups retain at most one running and one pending job. A PR cleanup and a new preview replaced the pending production job in the shared global group, so the production workflow was cancelled before starting.

## Validation

- npm run check
- actionlint
- shellcheck scripts/stage-site.sh
- git diff --check

This keeps each PR preview ordered while allowing production and unrelated previews to progress safely through rebase-based deployment commits.